### PR TITLE
Fixed broken download script

### DIFF
--- a/pages/download.rst
+++ b/pages/download.rst
@@ -107,7 +107,7 @@ Develop releases are snapshots of the current development.
    .. code:: sh
 
       CODENAME=`grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2`
-      if ["$CODENAME"] = ""]
+      if [ -z "$CODENAME" ]
       then
          CODENAME=`lsb_release -c -s`
       fi;
@@ -122,7 +122,7 @@ Develop releases are snapshots of the current development.
    .. code:: sh
 
       CODENAME=`grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2`
-      if ["$CODENAME"] = ""]
+      if [ -z "$CODENAME" ]
       then
          CODENAME=`lsb_release -c -s`
       fi;


### PR DESCRIPTION
The testing for $CODENAME was incorrect (mismatched braces caused it to fail), and could be done equivalently with `-z`

This fixes #26 