### PR TITLE
Removed references to nonexistent command line option `--windows-onefile-tempdir-spec`

### DIFF
--- a/doc/doc/user-manual.rst
+++ b/doc/doc/user-manual.rst
@@ -485,7 +485,7 @@ that.
 
 Again, on Windows, for the temporary file directory, by default the user
 one is used, however this can be overridden with a path specification
-given in ``--windows-onefile-tempdir-spec=%TEMP%\\onefile_%PID%_%TIME%``
+given in ``--onefile-tempdir-spec=%TEMP%\\onefile_%PID%_%TIME%``
 which is the default and asserts that the temporary directories created
 cannot collide.
 
@@ -910,7 +910,7 @@ Windows Programs without console give no errors
 For debugging purposes, remove ``--windows-disable-console`` or use the
 options ``--windows-force-stdout-spec`` and
 ``--windows-force-stderr-spec`` with paths as documented for
-``--windows-onefile-tempdir-spec`` above.
+``--onefile-tempdir-spec`` above.
 
 Deep copying uncompiled functions
 =================================


### PR DESCRIPTION
Hello.

On the ["User Manual"](https://nuitka.net/doc/user-manual.html) page some tips reference to  `--windows-onefile-tempdir-spec`, removed in [Nuitka 1.1](https://nuitka.net/posts/nuitka-release-11.html) and replaced by  `--onefile-tempdir-spec`. I fixed this oversight.

Thanks in advance.
