### PR TITLE
Update user-manual.rst

### DIFF
--- a/doc/doc/user-manual.rst
+++ b/doc/doc/user-manual.rst
@@ -507,7 +507,7 @@ and then deleted, however this default
 ``--onefile-tempdir-spec="%TEMP%/onefile_%PID%_%TIME%"`` can be
 overridden with a path specification that is using then using a cached
 path, avoiding repeated unpacking, e.g. with
-``--onefile-tempdir-spec="%CACHE_DIR%/%COMPANY%/%PRODUCT%/%VERSION"``
+``--onefile-tempdir-spec="%CACHE_DIR%/%COMPANY%/%PRODUCT%/%VERSION%"``
 which uses version information, and user specific cache directory.
 
 .. note::


### PR DESCRIPTION
A `%` was missing in the example for the `--onefile-tempdir-spec` parameter.

A [PR](https://github.com/Nuitka/Nuitka/pull/2203) with the same fix has been opened for the [README.rst ](https://github.com/Nuitka/Nuitka/blob/develop/README.rst)of the main repo.
