### PR TITLE
Update user-manual.rst example with missing line-end colon

### DIFF
--- a/doc/doc/user-manual.rst
+++ b/doc/doc/user-manual.rst
@@ -832,7 +832,7 @@ this should then be a bundle.
    # Compilation mode, standalone everywhere, except on macOS there app bundle
    # nuitka-project-if: {OS} in ("Windows", "Linux", "FreeBSD"):
    #    nuitka-project: --onefile
-   # nuitka-project-if: {OS} == "Darwin"
+   # nuitka-project-if: {OS} == "Darwin":
    #    nuitka-project: --standalone
    #    nuitka-project: --macos-create-app-bundle
    #


### PR DESCRIPTION
Without this colon, using this code returns the error: `FATAL: main.py:3 Error, 'nuitka-project-if' needs to start a block with a colon at line end.`