### PR TITLE
Fix typo in docs/user-manual.rst

### DIFF
--- a/doc/doc/user-manual.rst
+++ b/doc/doc/user-manual.rst
@@ -1013,7 +1013,7 @@ Misleading Messages
 -------------------
 
 Some packages output what they think is helpful information about what
-the reason of a failed import might me. With compiled programs there are
+the reason of a failed import might mean. With compiled programs there are
 very often just plain wrong. We try and repair those in non-deployment
 mode. Here is an example, where we change a message that asks to pip
 install (which is not the issue) to point the user to the include


### PR DESCRIPTION
This pull request corrects a small typo in the user manual by replacing the word "me" with "mean" in the "Misleading Messages" section of the docs/user-manual.rst file. 