### PR TITLE
Carousel tech added

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,7 +56,8 @@
 				"redhat.vscode-xml",
 				"eamodio.gitlens",
 				"swyddfa.esbonio",
-				"google.geminicodeassist"
+				"google.geminicodeassist",
+				"esbenp.prettier-vscode"
 			]
 		}
 	},

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,4 +34,10 @@
         "editor.defaultFormatter": "vscode.html-language-features"
     },
     "esbonio.server.installBehavior": "nothing",
+    "[postcss]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
 }

--- a/_ext/carousel.py
+++ b/_ext/carousel.py
@@ -1,42 +1,46 @@
-from docutils import nodes
-from sphinx.util.docutils import SphinxDirective
 from typing import List, cast
 
-def make_icon_node():
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+
+def makeIconNode():
     return nodes.raw(
-        '',
+        "",
         '<i class="fa fa-arrow-right sd-text-white" aria-hidden="true"></i>',
-        format='html'
+        format="html",
     )
+
 
 class CarouselContainer(SphinxDirective):
     has_content = True
 
     def run(self) -> List[nodes.Node]:
         container = nodes.container()
-        container['classes'] = ['carousel-rst-container']
+        container["classes"] = ["carousel-rst-container"]
 
         self.state.nested_parse(self.content, self.content_offset, container)
         return [container]
 
+
 class Carousel(SphinxDirective):
     option_spec = {
-        'tab-duration': int,
+        "tab-duration": int,
     }
     has_content = True
 
     def run(self) -> List[nodes.Node]:
         carousel = nodes.container()
-        carousel['classes'] = ['carousel']
+        carousel["classes"] = ["carousel"]
 
         top_controls = nodes.container()
-        top_controls['classes'] = ['carousel-top']
+        top_controls["classes"] = ["carousel-top"]
 
         content = nodes.container()
-        content['classes'] = ['carousel-content']
+        content["classes"] = ["carousel-content"]
 
         side_tabs = nodes.container()
-        side_tabs['classes'] = ['carousel-tabs-side']
+        side_tabs["classes"] = ["carousel-tabs-side"]
 
         temp_container = nodes.container()
         self.state.nested_parse(self.content, self.content_offset, temp_container)
@@ -44,29 +48,29 @@ class Carousel(SphinxDirective):
         tab_count = 0
         for child in temp_container.children:
             child_container = cast(nodes.container, child)
-            if 'carousel-main' in child_container.attributes.get('classes', []):
+            if "carousel-main" in child_container.attributes.get("classes", []):
                 content.append(child)
-                tab_name = child_container.attributes.get('tab-name')
+                tab_name = child_container.attributes.get("tab-name")
                 if tab_name:
-                    radio_html = f'''
+                    radio_html = f"""
                     <input type="radio" name="carousel-tab" id="carousel-tab-{tab_count}"
                            class="carousel-radio" {'checked' if tab_count == 0 else ''}>
-                    '''
-                    carousel += nodes.raw('', radio_html, format='html')
+                    """
+                    carousel += nodes.raw("", radio_html, format="html")
 
-                    label_html = f'''
+                    label_html = f"""
                     <label for="carousel-tab-{tab_count}" class="carousel-tab-top" data-duration={self.options.get('tab-duration', 5000)}>
                         {tab_name}
                         <div class="carousel-duration">
                             <div class="carousel-progress"></div>
                         </div>
                     </label>
-                    '''
-                    top_controls += nodes.raw('', label_html, format='html')
+                    """
+                    top_controls += nodes.raw("", label_html, format="html")
 
                     tab_count += 1
 
-            elif 'carousel-tab-side' in child_container.attributes.get('classes', []):
+            elif "carousel-tab-side" in child_container.attributes.get("classes", []):
                 side_tabs.append(child)
 
         carousel.append(top_controls)
@@ -75,120 +79,139 @@ class Carousel(SphinxDirective):
 
         return [carousel]
 
+
 class CarouselContent(SphinxDirective):
     has_content = True
     required_arguments = 1
     final_argument_whitespace = True
     option_spec = {
-        'doc': str,
-        'url': str,
+        "doc": str,
+        "url": str,
     }
 
     def run(self) -> List[nodes.Node]:
         tab_name = self.arguments[0]
 
         container = nodes.container()
-        container['classes'] = ['carousel-main']
-        container.attributes['tab-name'] = tab_name
+        container["classes"] = ["carousel-main"]
+        container.attributes["tab-name"] = tab_name
 
         if self.content:
             content_lines = list(self.content)
             heading_text = content_lines[0]
-            heading_node = nodes.raw('', f'<h2 class="carousel-heading">{heading_text}</h2>', format='html')
+            heading_node = nodes.raw(
+                "", f'<h2 class="carousel-heading">{heading_text}</h2>', format="html"
+            )
             container.append(heading_node)
 
             if len(content_lines) > 2:
-                text = '\n'.join(content_lines[1:-1])
-                text_node = nodes.paragraph(text=text, classes=['carousel-text'])
+                text = "\n".join(content_lines[1:-1])
+                text_node = nodes.paragraph(text=text, classes=["carousel-text"])
                 container.append(text_node)
 
             if len(content_lines) > 1:
                 cta_line = content_lines[-1]
 
                 link_url = None
-                if 'doc' in self.options:
-                    docname = self.options['doc']
+                if "doc" in self.options:
+                    docname = self.options["doc"]
                     env = self.env
                     if env.found_docs and docname in env.found_docs:
-                        link_url = env.app.builder.get_relative_uri(env.docname, docname)
+                        link_url = env.app.builder.get_relative_uri(
+                            env.docname, docname
+                        )
                     else:
                         link_url = f"{docname}.html"  # fallback
-                elif 'url' in self.options:
-                    link_url = self.options['url']
+                elif "url" in self.options:
+                    link_url = self.options["url"]
 
                 if link_url:
                     cta_html = f'<a href="{link_url}" class="carousel-button-link">{cta_line} <i class="fa fa-arrow-right sd-text-white" aria-hidden="true"></i></a>'
-                    cta_node = nodes.raw('', f'<div class="carousel-button">{cta_html}</div>', format='html')
+                    cta_node = nodes.raw(
+                        "",
+                        f'<div class="carousel-button">{cta_html}</div>',
+                        format="html",
+                    )
                 else:
                     inline_node = nodes.paragraph()
-                    self.state.nested_parse([cta_line], self.content_offset, inline_node)
-                    cta_node = nodes.container(classes=['carousel-button'])
+                    self.state.nested_parse(
+                        [cta_line], self.content_offset, inline_node
+                    )
+                    cta_node = nodes.container(classes=["carousel-button"])
                     cta_node.extend(inline_node.children)
-                    arrow_node = make_icon_node()
+                    arrow_node = makeIconNode()
                     cta_node.append(arrow_node)
 
                 container.append(cta_node)
 
         return [container]
 
+
 class CarouselSideTab(SphinxDirective):
     has_content = True
     required_arguments = 1
     final_argument_whitespace = True
     option_spec = {
-        'doc': str,
-        'url': str,
+        "doc": str,
+        "url": str,
     }
 
     def run(self) -> List[nodes.Node]:
         tab_heading = self.arguments[0]
-        content_text = '\n'.join(self.content)
+        content_text = "\n".join(self.content)
 
         container = nodes.container()
-        container['classes'] = ['carousel-tab-side']
+        container["classes"] = ["carousel-tab-side"]
 
         link_url = None
-        if 'doc' in self.options:
-            docname = self.options['doc']
+        if "doc" in self.options:
+            docname = self.options["doc"]
             env = self.env
             if env.found_docs and docname in env.found_docs:
                 link_url = env.app.builder.get_relative_uri(env.docname, docname)
             else:
                 link_url = f"{docname}.html"
-        elif 'url' in self.options:
-            link_url = self.options['url']
+        elif "url" in self.options:
+            link_url = self.options["url"]
 
         if link_url:
-            tab_html = f'''
+            tab_html = f"""
             <a href="{link_url}" class="carousel-tab-side-link">
                 <div class="carousel-tab-heading">{tab_heading}</div>
                 <div class="carousel-tab-content">{content_text}</div>
             </a>
-            '''
+            """
 
-            arrow_node = f'''
+            arrow_node = f"""
             <a href="{link_url}" class="carousel-tab-arrow">
                 <i class="fa fa-arrow-right sd-text-black" aria-hidden="true"></i>
-            </a>'''
+            </a>"""
 
-            container += nodes.raw('', tab_html, format='html')
-            container += nodes.raw('', arrow_node, format='html')
+            container += nodes.raw("", tab_html, format="html")
+            container += nodes.raw("", arrow_node, format="html")
         else:
-            heading = nodes.paragraph(text=tab_heading, classes=['carousel-tab-heading'])
+            heading = nodes.paragraph(
+                text=tab_heading, classes=["carousel-tab-heading"]
+            )
             content = nodes.paragraph(text=content_text)
-            arrow_node = make_icon_node()
+            arrow_node = makeIconNode()
             container.append(heading)
             container.append(content)
             container.append(arrow_node)
 
         return [container]
 
+
 def setup(app):
     app.add_directive("carousel-container", CarouselContainer)
     app.add_directive("carousel", Carousel)
     app.add_directive("carousel-content", CarouselContent)
     app.add_directive("carousel-side-tab", CarouselSideTab)
-    app.connect('builder-inited', lambda app: app.add_js_file('carousel.js'))
+
+    def builderInit(app):
+        app.add_js_file("carousel.js")
+
+    app.connect("builder-inited", builderInit)
 
     return {
         "version": "0.1",

--- a/_ext/carousel.py
+++ b/_ext/carousel.py
@@ -1,0 +1,197 @@
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from typing import List, cast
+
+def make_icon_node():
+    return nodes.raw(
+        '',
+        '<i class="fa fa-arrow-right sd-text-white" aria-hidden="true"></i>',
+        format='html'
+    )
+
+class CarouselContainer(SphinxDirective):
+    has_content = True
+
+    def run(self) -> List[nodes.Node]:
+        container = nodes.container()
+        container['classes'] = ['carousel-rst-container']
+
+        self.state.nested_parse(self.content, self.content_offset, container)
+        return [container]
+
+class Carousel(SphinxDirective):
+    option_spec = {
+        'tab-duration': int,
+    }
+    has_content = True
+
+    def run(self) -> List[nodes.Node]:
+        carousel = nodes.container()
+        carousel['classes'] = ['carousel']
+
+        top_controls = nodes.container()
+        top_controls['classes'] = ['carousel-top']
+
+        content = nodes.container()
+        content['classes'] = ['carousel-content']
+
+        side_tabs = nodes.container()
+        side_tabs['classes'] = ['carousel-tabs-side']
+
+        temp_container = nodes.container()
+        self.state.nested_parse(self.content, self.content_offset, temp_container)
+
+        tab_count = 0
+        for child in temp_container.children:
+            child_container = cast(nodes.container, child)
+            if 'carousel-main' in child_container.attributes.get('classes', []):
+                content.append(child)
+                tab_name = child_container.attributes.get('tab-name')
+                if tab_name:
+                    radio_html = f'''
+                    <input type="radio" name="carousel-tab" id="carousel-tab-{tab_count}"
+                           class="carousel-radio" {'checked' if tab_count == 0 else ''}>
+                    '''
+                    carousel += nodes.raw('', radio_html, format='html')
+
+                    label_html = f'''
+                    <label for="carousel-tab-{tab_count}" class="carousel-tab-top" data-duration={self.options.get('tab-duration', 5000)}>
+                        {tab_name}
+                        <div class="carousel-duration">
+                            <div class="carousel-progress"></div>
+                        </div>
+                    </label>
+                    '''
+                    top_controls += nodes.raw('', label_html, format='html')
+
+                    tab_count += 1
+
+            elif 'carousel-tab-side' in child_container.attributes.get('classes', []):
+                side_tabs.append(child)
+
+        carousel.append(top_controls)
+        carousel.append(content)
+        carousel.append(side_tabs)
+
+        return [carousel]
+
+class CarouselContent(SphinxDirective):
+    has_content = True
+    required_arguments = 1
+    final_argument_whitespace = True
+    option_spec = {
+        'doc': str,
+        'url': str,
+    }
+
+    def run(self) -> List[nodes.Node]:
+        tab_name = self.arguments[0]
+
+        container = nodes.container()
+        container['classes'] = ['carousel-main']
+        container.attributes['tab-name'] = tab_name
+
+        if self.content:
+            content_lines = list(self.content)
+            heading_text = content_lines[0]
+            heading_node = nodes.raw('', f'<h2 class="carousel-heading">{heading_text}</h2>', format='html')
+            container.append(heading_node)
+
+            if len(content_lines) > 2:
+                text = '\n'.join(content_lines[1:-1])
+                text_node = nodes.paragraph(text=text, classes=['carousel-text'])
+                container.append(text_node)
+
+            if len(content_lines) > 1:
+                cta_line = content_lines[-1]
+
+                link_url = None
+                if 'doc' in self.options:
+                    docname = self.options['doc']
+                    env = self.env
+                    if env.found_docs and docname in env.found_docs:
+                        link_url = env.app.builder.get_relative_uri(env.docname, docname)
+                    else:
+                        link_url = f"{docname}.html"  # fallback
+                elif 'url' in self.options:
+                    link_url = self.options['url']
+
+                if link_url:
+                    cta_html = f'<a href="{link_url}" class="carousel-button-link">{cta_line} <i class="fa fa-arrow-right sd-text-white" aria-hidden="true"></i></a>'
+                    cta_node = nodes.raw('', f'<div class="carousel-button">{cta_html}</div>', format='html')
+                else:
+                    inline_node = nodes.paragraph()
+                    self.state.nested_parse([cta_line], self.content_offset, inline_node)
+                    cta_node = nodes.container(classes=['carousel-button'])
+                    cta_node.extend(inline_node.children)
+                    arrow_node = make_icon_node()
+                    cta_node.append(arrow_node)
+
+                container.append(cta_node)
+
+        return [container]
+
+class CarouselSideTab(SphinxDirective):
+    has_content = True
+    required_arguments = 1
+    final_argument_whitespace = True
+    option_spec = {
+        'doc': str,
+        'url': str,
+    }
+
+    def run(self) -> List[nodes.Node]:
+        tab_heading = self.arguments[0]
+        content_text = '\n'.join(self.content)
+
+        container = nodes.container()
+        container['classes'] = ['carousel-tab-side']
+
+        link_url = None
+        if 'doc' in self.options:
+            docname = self.options['doc']
+            env = self.env
+            if env.found_docs and docname in env.found_docs:
+                link_url = env.app.builder.get_relative_uri(env.docname, docname)
+            else:
+                link_url = f"{docname}.html"
+        elif 'url' in self.options:
+            link_url = self.options['url']
+
+        if link_url:
+            tab_html = f'''
+            <a href="{link_url}" class="carousel-tab-side-link">
+                <div class="carousel-tab-heading">{tab_heading}</div>
+                <div class="carousel-tab-content">{content_text}</div>
+            </a>
+            '''
+
+            arrow_node = f'''
+            <a href="{link_url}" class="carousel-tab-arrow">
+                <i class="fa fa-arrow-right sd-text-black" aria-hidden="true"></i>
+            </a>'''
+
+            container += nodes.raw('', tab_html, format='html')
+            container += nodes.raw('', arrow_node, format='html')
+        else:
+            heading = nodes.paragraph(text=tab_heading, classes=['carousel-tab-heading'])
+            content = nodes.paragraph(text=content_text)
+            arrow_node = make_icon_node()
+            container.append(heading)
+            container.append(content)
+            container.append(arrow_node)
+
+        return [container]
+
+def setup(app):
+    app.add_directive("carousel-container", CarouselContainer)
+    app.add_directive("carousel", Carousel)
+    app.add_directive("carousel-content", CarouselContent)
+    app.add_directive("carousel-side-tab", CarouselSideTab)
+    app.connect('builder-inited', lambda app: app.add_js_file('carousel.js'))
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/_static/carousel.js
+++ b/_static/carousel.js
@@ -1,0 +1,51 @@
+window.addEventListener("load", function () {
+	const carousels = document.querySelectorAll(".carousel");
+	carousels.forEach((carousel) => {
+		const radios = carousel.querySelectorAll(".carousel-radio");
+		const labels = carousel.querySelectorAll(".carousel-tab-top");
+
+		let current = 0;
+		let autoplay = true;
+		let timeoutId = null;
+
+		function getDuration(index) {
+			const label = labels[index];
+			const duration = label?.getAttribute("data-duration");
+			return parseInt(duration, 10);
+		}
+
+		function goTo(index) {
+			radios[index].checked = true;
+			current = index;
+		}
+
+		function nextSlide() {
+			if (!autoplay) return;
+
+			const next = (current + 1) % radios.length;
+			goTo(next);
+			scheduleNext();
+		}
+
+		function scheduleNext() {
+			clearTimeout(timeoutId);
+			timeoutId = setTimeout(nextSlide, getDuration(current));
+		}
+
+		labels.forEach((label, index) => {
+			label.addEventListener("click", () => {
+				autoplay = false;
+
+				const durationBars = carousel.querySelectorAll(".carousel-duration");
+
+				durationBars.forEach((bar) => bar.remove());
+
+				goTo(index);
+				clearTimeout(timeoutId);
+			});
+		});
+
+		goTo(current);
+		scheduleNext();
+	});
+});

--- a/_static/my_theme.css
+++ b/_static/my_theme.css
@@ -4,6 +4,7 @@
 	--our-color-grey: #ccc;
 	--our-color-dark-blue: #2a3990;
 	--our-color-green: #00916e;
+	--our-carousel-light-blue: #d2e6f4;
 }
 
 /* Google Chrome still hates our menu
@@ -833,4 +834,201 @@ details.sd-dropdown > .sd-summary-content {
 	border-top: 1px solid #e0e0e0;
 	color: #444;
 	margin-top: 0.5em;
+}
+
+.carousel {
+	max-width: 1200px;
+	margin: 0 auto;
+	border: 1px solid var(--our-carousel-light-blue);
+	background: white;
+	padding: 24px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.carousel * a,
+.carousel * a:visited,
+.carousel * a:hover,
+.carousel * a:active {
+	all: unset;
+	cursor: pointer;
+}
+
+.carousel-main {
+	display: none;
+	padding: 0rem 3rem 3rem 3rem;
+}
+
+.carousel .carousel-radio {
+	display: none;
+}
+
+.carousel-main .carousel-button {
+	align-self: flex-start;
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	background-color: var(--our-color-blue);
+	color: white;
+	padding: 12px 24px;
+	border: none;
+	border-radius: 8px;
+	cursor: pointer;
+	font-size: 1rem;
+	font-weight: 600;
+	transition:
+		background-color 0.3s ease,
+		transform 0.2s ease;
+	text-decoration: none;
+	width: fit-content;
+}
+
+.carousel-main .carousel-button:hover {
+	background-color: var(--our-carousel-light-blue);
+	transform: translateY(-2px);
+}
+
+.carousel-main .carousel-button:active {
+	transform: translateY(0);
+}
+
+.carousel-tabs-side {
+	display: none;
+}
+
+@media (min-width: 992px) {
+	.carousel-tabs-side {
+		display: flex;
+		justify-content: center;
+		gap: 1rem;
+	}
+}
+
+.carousel-tab-side {
+	background-color: var(--our-carousel-light-blue);
+	padding: 16px;
+	font-size: 0.95rem;
+	font-weight: 500;
+	border-radius: 6px;
+	overflow-wrap: break-word;
+	max-width: 250px;
+	width: 100%;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+}
+
+.carousel-duration {
+	background-color: var(--our-carousel-light-blue);
+	height: 4px;
+	overflow: hidden;
+	width: 100%;
+	margin-top: 2px;
+	display: none;
+}
+
+.carousel-tab-heading {
+	margin-bottom: 0.5rem;
+}
+
+.carousel-progress {
+	background-color: var(--our-color-dark-blue);
+	width: 100%;
+	height: 100%;
+	animation: progress 5s linear forwards;
+}
+
+@keyframes progress {
+	0% {
+		width: 0;
+	}
+	100% {
+		width: 100%;
+	}
+}
+
+.carousel-top {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.carousel-tab-top {
+	background: var(--our-carousel-light-blue);
+	color: #333;
+	font-weight: 500;
+	padding: 10px 20px;
+	cursor: pointer;
+	border: 2px solid transparent;
+	transition: all 0.3s ease;
+	font-size: 1rem;
+}
+
+.carousel-tab-top:hover {
+	background: var(--our-color-blue);
+}
+
+.carousel-tab-arrow {
+	font-size: 1.2rem;
+}
+
+/* Make the active tab stand out */
+.carousel-radio#carousel-tab-0:checked ~ .carousel-top
+	label[for="carousel-tab-0"],
+.carousel-radio#carousel-tab-1:checked
+	~ .carousel-top
+	label[for="carousel-tab-1"],
+.carousel-radio#carousel-tab-2:checked
+	~ .carousel-top
+	label[for="carousel-tab-2"],
+.carousel-radio#carousel-tab-3:checked
+	~ .carousel-top
+	label[for="carousel-tab-3"] {
+	background: var(--our-color-blue);
+	color: white;
+	border-color: var(--our-color-blue);
+	font-weight: 600;
+}
+
+/* Show the content of the active tab */
+#carousel-tab-0:checked
+	~ .carousel-top
+	~ .carousel-content
+	.carousel-main:nth-child(1),
+#carousel-tab-1:checked
+	~ .carousel-top
+	~ .carousel-content
+	.carousel-main:nth-child(2),
+#carousel-tab-2:checked
+	~ .carousel-top
+	~ .carousel-content
+	.carousel-main:nth-child(3),
+#carousel-tab-3:checked
+	~ .carousel-top
+	~ .carousel-content
+	.carousel-main:nth-child(4) {
+	display: block;
+}
+
+/* Show the duration bar only for the active tab */
+.carousel-radio#carousel-tab-0:checked ~ .carousel-top
+	label[for="carousel-tab-0"]
+	.carousel-duration,
+.carousel-radio#carousel-tab-1:checked
+	~ .carousel-top
+	label[for="carousel-tab-1"]
+	.carousel-duration,
+.carousel-radio#carousel-tab-2:checked
+	~ .carousel-top
+	label[for="carousel-tab-2"]
+	.carousel-duration,
+.carousel-radio#carousel-tab-3:checked
+	~ .carousel-top
+	label[for="carousel-tab-3"]
+	.carousel-duration {
+	display: block;
 }

--- a/shared_conf.py
+++ b/shared_conf.py
@@ -2,6 +2,7 @@ import sys
 import time
 from pathlib import Path
 
+
 # Configuration file for the Sphinx documentation builder.
 
 # -- Project information
@@ -11,8 +12,15 @@ author = "Kay Hayen"
 release = version = ""
 
 ROOT = Path(__file__).parent.absolute().as_posix()  # The root directory
+
 # For autodoc to work
 sys.path.append(ROOT)
+
+# Add _ext directory to Python path for custom Sphinx extensions
+_ext_path = str(ROOT.parent / '_ext')
+if _ext_path not in sys.path:
+    sys.path.append(_ext_path)
+
 from update import importNuitka  # isort:skip
 
 importNuitka()
@@ -38,6 +46,7 @@ extensions = [
     "sphinxcontrib.asciinema",
     # Blog extension
     "ablog",
+    "carousel"
 ]
 
 intersphinx_mapping = {
@@ -102,11 +111,9 @@ favicons = [
 # -- Options for EPUB output
 epub_show_urls = "footnote"
 
-
 # Enable our own CSS to be used.
 def setup(app):
     app.add_css_file("my_theme.css")
-
 
 # Configure theme
 html_theme_options = {

--- a/shared_conf.py
+++ b/shared_conf.py
@@ -1,7 +1,7 @@
+import os
 import sys
 import time
 from pathlib import Path
-
 
 # Configuration file for the Sphinx documentation builder.
 
@@ -17,7 +17,7 @@ ROOT = Path(__file__).parent.absolute().as_posix()  # The root directory
 sys.path.append(ROOT)
 
 # Add _ext directory to Python path for custom Sphinx extensions
-_ext_path = str(ROOT.parent / '_ext')
+_ext_path = os.path.join(ROOT, "_ext")
 if _ext_path not in sys.path:
     sys.path.append(_ext_path)
 
@@ -46,7 +46,7 @@ extensions = [
     "sphinxcontrib.asciinema",
     # Blog extension
     "ablog",
-    "carousel"
+    "carousel",
 ]
 
 intersphinx_mapping = {
@@ -111,9 +111,11 @@ favicons = [
 # -- Options for EPUB output
 epub_show_urls = "footnote"
 
+
 # Enable our own CSS to be used.
 def setup(app):
     app.add_css_file("my_theme.css")
+
 
 # Configure theme
 html_theme_options = {

--- a/shared_conf.py
+++ b/shared_conf.py
@@ -16,15 +16,14 @@ ROOT = Path(__file__).parent.absolute().as_posix()  # The root directory
 # For autodoc to work
 sys.path.append(ROOT)
 
-# Add _ext directory to Python path for custom Sphinx extensions
-_ext_path = os.path.join(ROOT, "_ext")
-if _ext_path not in sys.path:
-    sys.path.append(_ext_path)
-
 from update import importNuitka  # isort:skip
 
 importNuitka()
 del sys.path[-1]
+
+# Add _ext directory to Python path for custom Sphinx extensions
+_ext_path = os.path.join(ROOT, "_ext")
+sys.path.append(_ext_path)
 
 # -- General configuration
 

--- a/site/welcome.rst
+++ b/site/welcome.rst
@@ -4,62 +4,74 @@
  Welcome to **Nuitka** Design Test Page
 ########################################
 
-On this page, we are striving to turn the tab set below into a full fledged carousel displaying the contents.
+On this page, we are striving to turn the tab set below into a full
+fledged carousel displaying the contents.
 
-.. tab-set::
-   :class: carousel persona-carousel
+.. carousel-container::
 
-   .. tab-item:: Deployment
-      :class-label: carousel-label carousel-persona-marina
-      :class-container: carousel-container carousel-persona-marina
-      :class-content: carousel-content carousel-persona-marina
+   .. carousel::
 
-      Dear Nuitka for Deployment User,
+      .. carousel-content:: Deployment
+         :doc: deployment-tour
 
-      see how to get started with deploying your software using Nuitka, it's
-      easy and we are there to guide you and help you through it. Many people
-      say it works out of the box, but if your software is very complex, we
-      can help you get it done.
+         Dear Nuitka for Deployment User
 
-      Take the Deployment tour
+         See how to get started with deploying your software using Nuitka, it's
+         easy and we are there to guide you and help you through it. Many people
+         say it works out of the box, but if your software is very complex, we
+         can help you get it done.
 
-   .. tab-item:: Beginner
-      :class-label: carousel-label carousel-persona-billy
-      :class-container: carousel-container carousel-persona-billy
-      :class-content: carousel-content carousel-persona-billy
+         Take the Deployment Tour
 
+      .. carousel-content:: Beginner
+         :doc: beginner-tour
 
-      Dear Python Beginner,
+         Dear Python Beginner
 
-      you and I know you are not at all familiar and you need help. Get
-      potentially instant help from a community of volunteers. TODO: Discord
-      Link
+         You and I know you are not at all familiar and you need help. Get
+         potentially instant help from a community of volunteers.
 
-      Take the Beginner Tour
+         Take the Beginner Tour
 
-   .. tab-item:: IT Manager
-      :class-label: carousel-label carousel-persona-cesar
-      :class-container: carousel-container carousel-persona-cesar
-      :class-content: carousel-content carousel-persona-cesar
+      .. carousel-content:: IT Manager
+         :doc: it-manager-tour
 
-      Dear IT Manager,
+         Dear IT Manager
 
-      see how your business can benefit from Nuitka with IP protection and its
-      powerful deployment solutions. Also, see the many convenience features
-      that can save your team a bunch of development time.
+         See how your business can benefit from Nuitka with IP protection and its
+         powerful deployment solutions. Also, see the many convenience features
+         that can save your team a bunch of development time.
 
-      Take the IT manager tour
+         Take the IT Manager Tour
 
-   .. tab-item:: Advanced Pythonista
-      :class-label: carousel-label carousel-persona-laura
-      :class-container: carousel-container carousel-persona-laura
-      :class-content: carousel-content carousel-persona-laura
+      .. carousel-content:: Advanced Pythonista
+         :doc: advanced-tour
 
-      Dear Python expert,
+         Dear Python Expert
 
-      you have ideas about what Nuitka is, and we are here to answer them in
-      great detail (eventually). Explore the power of Nuitka for deployment,
-      performance, and IP protection with more details and expert knowledge
-      used.
+         You have ideas about what Nuitka is, and we are here to answer them in
+         great detail (eventually). Explore the power of Nuitka for deployment,
+         performance, and IP protection with more details and expert knowledge
+         used.
 
-      Take the Advanced Tour
+         Take the Advanced Tour
+
+      .. carousel-side-tab:: Deployment
+         :doc: deployment-tour
+
+         Create standalone executables and protect your IP.
+
+      .. carousel-side-tab:: Beginner
+         :doc: beginner-tour
+
+         Simple guides and community support for newcomers.
+
+      .. carousel-side-tab:: IT Manager
+         :doc: it-manager-tour
+
+         Enterprise solutions with IP protection and cost savings.
+
+      .. carousel-side-tab:: Advanced Pythonista
+         :doc: advanced-tour
+
+         Advanced optimization and cutting-edge features.

--- a/site/welcome.rst
+++ b/site/welcome.rst
@@ -71,7 +71,7 @@ fledged carousel displaying the contents.
 
          Enterprise solutions with IP protection and cost savings.
 
-      .. carousel-side-tab:: Advanced Pythonista
+      .. carousel-side-tab:: Pythonista
          :doc: advanced-tour
 
          Advanced optimization and cutting-edge features.

--- a/tasks.py
+++ b/tasks.py
@@ -22,7 +22,7 @@ def virtualenv(c):
 
     # Workaround pipenv failing to pin black version due to it being pre-release
     # always.
-    # c.run(f"{sys.executable} -m pipenv run python -m pip install black==24.10.0")
+    c.run(f"{sys.executable} -m pipenv run python -m pip install black==24.10.0")
 
 
 @task

--- a/update.py
+++ b/update.py
@@ -675,8 +675,9 @@ def _getTranslationFileSet(filename):
 
 
 js_order = [
+    "jquery.js"
+    "carousel.js",
     "documentation_options.js",
-    "jquery.js",
     "_sphinx_javascript_frameworks_compat.js",
     "doctools.js",
     "sphinx_highlight.js",
@@ -684,16 +685,9 @@ js_order = [
     "clipboard.min.js",
     "copybutton.js",
     "translations.js",
-    "design-tabs.js",
 ]
 
-
 def _makeJsCombined(js_filenames):
-    js_filenames = list(js_filenames)
-    if "_static/jquery.js" not in js_filenames:
-        js_filenames.append("_static/jquery.js")
-    js_filenames.sort(key=lambda x: js_order.index(os.path.basename(x)))
-
     js_set_contents = (
         "\n".join(getFileContents(f"output/{js_name}") for js_name in js_filenames)
         + """

--- a/update.py
+++ b/update.py
@@ -836,25 +836,25 @@ def handleJavaScript(filename, doc):
         elif not has_carousel and "carousel" in script_tag.attrib["src"]:
             script_tag.getparent().remove(script_tag)
         else:
+            # Make script source absolute, so it's easier to find
+            if not script_tag.attrib["src"].startswith("/"):
+                while script_tag.attrib["src"].startswith("../"):
+                    script_tag.attrib["src"] = script_tag.attrib["src"][3:]
+
+                for translation in _translations:
+                    if translation in filename:
+                        script_tag.attrib["src"] = (
+                            "/" + translation + "/" + script_tag.attrib["src"]
+                        )
+                        break
+                else:
+                    script_tag.attrib["src"] = "/" + script_tag.attrib["src"]
             if script_tag_first is None:
                 script_tag_first = script_tag
             else:
                 script_tag.getparent().remove(script_tag)
 
-                # Make script source absolute, so it's easier to find
-                if not script_tag.attrib["src"].startswith("/"):
-                    while script_tag.attrib["src"].startswith("../"):
-                        script_tag.attrib["src"] = script_tag.attrib["src"][3:]
-
-                    for translation in _translations:
-                        if translation in filename:
-                            script_tag.attrib["src"] = (
-                                "/" + translation + "/" + script_tag.attrib["src"]
-                            )
-                            break
-                    else:
-                        script_tag.attrib["src"] = "/" + script_tag.attrib["src"]
-
+            assert script_tag.attrib["src"][0] == "/", script_tag.attrib["src"]
             js_filenames.append(script_tag.attrib["src"][1:])
 
     if script_tag_first is not None:

--- a/update.py
+++ b/update.py
@@ -675,7 +675,7 @@ def _getTranslationFileSet(filename):
 
 
 js_order = [
-    "jquery.js"
+    "jquery.js",
     "carousel.js",
     "documentation_options.js",
     "_sphinx_javascript_frameworks_compat.js",
@@ -686,6 +686,7 @@ js_order = [
     "copybutton.js",
     "translations.js",
 ]
+
 
 def _makeJsCombined(js_filenames):
     js_set_contents = (

--- a/update.py
+++ b/update.py
@@ -691,16 +691,6 @@ js_order = [
 def _makeJsCombined(js_filenames):
     js_filenames = list(js_filenames)
 
-    print("W", js_filenames)
-
-    # TODO: Below we inject jQuery for search box anyway, so the check is
-    # pointless, but we probably need not call
-    # "SphinxRtdTheme.Navigation.enable" at all.
-    for js_filename in js_filenames:
-        if "jQuery" in getFileContents(f"output/{js_filename}"):
-            js_filenames.insert(0, "_static/jquery.js")
-            break
-
     js_set_contents = (
         "\n".join(
             getFileContents(f"output/{js_filename}") for js_filename in js_filenames

--- a/update.py
+++ b/update.py
@@ -697,7 +697,9 @@ def _makeJsCombined(js_filenames):
             break
 
     js_set_contents = (
-        "\n".join(getFileContents(f"output/{js_filename}") for js_filename in js_filenames)
+        "\n".join(
+            getFileContents(f"output/{js_filename}") for js_filename in js_filenames
+        )
         + """
 jQuery(function () {
     SphinxRtdTheme.Navigation.enable(true);
@@ -804,6 +806,10 @@ def runPostProcessing():
         # Check copybutton.js
         has_highlight = doc.xpath("//div[@class='highlight']")
 
+        # Check carousel.js
+        has_carousel = doc.xpath("//div[@class='carousel']")
+
+        # Check inline tabs
         has_inline_tabs = doc.xpath("//*[@class='sd-tab-label']")
 
         # Detect if asciinema is used in the page
@@ -1075,6 +1081,8 @@ def runPostProcessing():
             elif not has_highlight and "clipboard" in script_tag.attrib["src"]:
                 script_tag.getparent().remove(script_tag)
             elif not has_inline_tabs and "design-tabs" in script_tag.attrib["src"]:
+                script_tag.getparent().remove(script_tag)
+            elif not has_carousel and "carousel" in script_tag.attrib["src"]:
                 script_tag.getparent().remove(script_tag)
             else:
                 if script_tag_first is None:

--- a/update.py
+++ b/update.py
@@ -768,7 +768,7 @@ def handleJavaScript(filename, doc):
     has_highlight = doc.xpath("//div[@class='highlight']")
 
     # Check carousel.js
-    has_carousel = doc.xpath("//div[@class='carousel']")
+    has_carousel = doc.xpath("//div[contains(@class, 'carousel')]")
 
     # Check inline tabs
     has_inline_tabs = doc.xpath("//*[@class='sd-tab-label']")
@@ -848,8 +848,6 @@ def handleJavaScript(filename, doc):
             js_filenames.append(script_tag.attrib["src"][1:])
 
     if script_tag_first is not None:
-        if "welcome" in filename:
-            print("JS", filename, js_filenames)
         script_tag_first.attrib["src"] = _makeJsCombined(js_filenames)
 
 

--- a/update.py
+++ b/update.py
@@ -689,8 +689,15 @@ js_order = [
 
 
 def _makeJsCombined(js_filenames):
+    js_filenames = list(js_filenames)
+
+    for js_filename in js_filenames:
+        if "jQuery" in getFileContents(f"output/{js_filename}"):
+            js_filenames.insert(0, "_static/jquery.js")
+            break
+
     js_set_contents = (
-        "\n".join(getFileContents(f"output/{js_name}") for js_name in js_filenames)
+        "\n".join(getFileContents(f"output/{js_filename}") for js_filename in js_filenames)
         + """
 jQuery(function () {
     SphinxRtdTheme.Navigation.enable(true);

--- a/update.py
+++ b/update.py
@@ -691,6 +691,11 @@ js_order = [
 def _makeJsCombined(js_filenames):
     js_filenames = list(js_filenames)
 
+    print("W", js_filenames)
+
+    # TODO: Below we inject jQuery for search box anyway, so the check is
+    # pointless, but we probably need not call
+    # "SphinxRtdTheme.Navigation.enable" at all.
     for js_filename in js_filenames:
         if "jQuery" in getFileContents(f"output/{js_filename}"):
             js_filenames.insert(0, "_static/jquery.js")
@@ -850,7 +855,7 @@ def handleJavaScript(filename, doc):
                     else:
                         script_tag.attrib["src"] = "/" + script_tag.attrib["src"]
 
-                js_filenames.append(script_tag.attrib["src"][1:])
+            js_filenames.append(script_tag.attrib["src"][1:])
 
     if script_tag_first is not None:
         if "welcome" in filename:


### PR DESCRIPTION
## Summary by Sourcery

Implement a new Personas Carousel feature by adding a Sphinx extension with custom directives, associated static CSS and JavaScript assets, and integrating them into the build process.

New Features:
- Introduce a carousel Sphinx extension with directives for containers, main content slides, and side tabs
- Add carousel-specific CSS in my_theme.css to style carousel layout, navigation tabs, and progress animations
- Add a carousel.js script to enable auto-rotating slides and interactive controls
- Register the new 'carousel' extension in shared_conf.py and include its path in site/conf.py

Enhancements:
- Reorder the JS combine logic in update.py to ensure jQuery is always loaded first and include carousel.js in the build sequence
- Normalize indentation and whitespace throughout my_theme.css for consistency