### PR TITLE
[FIXES] Broken SVGs & more

### DIFF
--- a/_static/my_theme.css
+++ b/_static/my_theme.css
@@ -16,6 +16,18 @@ html {
 }
 */
 
+.nuitka-fa {
+  display: inline-block;
+  width: 1em;               
+  height: 1em;
+  vertical-align: middle;
+}
+
+.nuitka-fw {
+	 width: 1.25em;
+  text-align: center;
+}
+
 .wy-nav-top svg {
 	width: 30px;
 	float: left;

--- a/tests/const.py
+++ b/tests/const.py
@@ -36,6 +36,7 @@ GOLDEN_PAGES = [
     "doc/commercial/protect-data-files.html",
     "user-documentation/tips.html",
     "pages/website-manual.html",
+    "posts/nuitka-shaping-up.html"
 ]
 
 DEFAULT_WAIT_TIME = 1000

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,7 +46,7 @@ def takeScreenshot(browser, url, mode, base_path=CURRENT_DIR, wait_time=DEFAULT_
     page = context.new_page()
 
     page.goto(url, timeout=20000)
-    my_my_print(f"  Taking screenshot of {url} ({browser_name}, {mode})")
+    my_print(f"  Taking screenshot of {url} ({browser_name}, {mode})")
 
     if wait_time > 0:
         page.wait_for_timeout(wait_time)

--- a/update.py
+++ b/update.py
@@ -137,6 +137,10 @@ FA_UTILITY_CLASSES = {
 
 FA_SVG_PATH = "site/images/fontawesome"
 
+FA_REPLACEMENT_CLASS = {
+    "fa": "nuitka-fa",
+    "fa-fw": "nuitka-fw",
+}
 
 def add_inline_svg(
     element, svg_path, is_fa_icon=False, style_folder=None, icon_name=None
@@ -187,6 +191,12 @@ def add_inline_svg(
             continue
 
         svg_element.set(attr, element.get(attr))
+
+    if is_fa_icon:
+        class_attr = svg_element.get("class", element.get("class", ""))
+        class_list = class_attr.split()
+        class_list = [FA_REPLACEMENT_CLASS.get(cl, cl) for cl in class_list]
+        svg_element.set("class", " ".join(class_list))
 
     parent = element.getparent()
     tail = element.tail


### PR DESCRIPTION
Just made a few changes, nothing crazy.

@kayhayen 
Please merge as soon as possible. I fixed a small typo in the tests that I hadn’t noticed.

## Summary by Sourcery

Add custom CSS and mapping to correctly inline FontAwesome SVG icons, fix a typo in the test utility, and include a new HTML page in the test constants.

Bug Fixes:
- Correct the test screenshot utility call by renaming my_my_print to my_print.

Enhancements:
- Define .nuitka-fa and .nuitka-fw CSS classes and map fa/fa-fw to these classes during SVG inlining.

Tests:
- Add posts/nuitka-shaping-up.html to the list of pages used in visual tests.