### PR TITLE
FIX - Cache key

### DIFF
--- a/.github/workflows/update-golden-images.yml
+++ b/.github/workflows/update-golden-images.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Start app for screenshots
         run: |
-          export DEVELOPMENT_MODE=1
           pipenv run invoke update-docs
           pipenv run invoke site
           pipenv run invoke post-process

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Start app for visual regression tests
         run: |
           echo "Starting app..."
-          export DEVELOPMENT_MODE=1
           pipenv run invoke update-docs
           pipenv run invoke site
           pipenv run invoke post-process


### PR DESCRIPTION
## Summary by Sourcery

Include GitHub run number in the cache key for golden images in the update-golden-images workflow to avoid cache collisions

Bug Fixes:
- Append GitHub run number to the golden images cache key to prevent reuse of outdated caches across runs

CI:
- Adjust cache key in update-golden-images workflow to include github.run_number context