### PR TITLE
[FIX] Fix SVG issues in production

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -90,6 +90,8 @@ module.exports = {
 				/^current/,
 				// Utility classes
 				/^highlight/,
+				"nuitka-fa",
+				"nuitka-fw",
 			],
 			defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
 		}),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Safelist 'nuitka-fa' and 'nuitka-fw' classes in PurgeCSS to prevent SVG icons from being removed in production