### PR TITLE
[FIX] Dev mode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,19 +25,6 @@
             }
         },
         {
-            "label": "stop auto-update.sh",
-            "type": "shell",
-            "command": "pkill -f auto-update.sh || true",
-            "options": {
-                "cwd": "${workspaceFolder}"
-            },
-            "problemMatcher": [],
-            "presentation": {
-                "reveal": "never"
-            },
-            "detail": "Stop any running auto-update.sh processes"
-        },
-        {
             "label": "rebuild all pages",
             "type": "shell",
             "command": "killall -SIGUSR2 sphinx-autobuild",
@@ -52,22 +39,20 @@
         {
             "label": "run development mode",
             "type": "shell",
-            "command": "./auto-update.sh --development",
+            "command": "sed -i 's/^development_mode = .*$/development_mode = true/' settings.ini",
             "options": {
                 "cwd": "${workspaceFolder}"
             },
             "problemMatcher": [],
-            "dependsOn": ["stop auto-update.sh"]
         },
         {
             "label": "run production mode",
             "type": "shell",
-            "command": "./auto-update.sh --production",
+            "command": "sed -i 's/^development_mode = .*$/development_mode = false/' settings.ini",
             "options": {
                 "cwd": "${workspaceFolder}"
             },
             "problemMatcher": [],
-            "dependsOn": ["stop auto-update.sh"]
         },
         {
             "label": "auto-format current file",

--- a/auto-update.sh
+++ b/auto-update.sh
@@ -1,29 +1,5 @@
 #!/bin/bash
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --development)
-            DEVELOPMENT_MODE=1
-            echo "Overriding to DEVELOPMENT mode (from flag)" | tee -a auto-update.log
-            shift
-            ;;
-        --production)
-            DEVELOPMENT_MODE=0
-            echo "Overriding to PRODUCTION mode (from flag)" | tee -a auto-update.log
-            shift
-            ;;
-        *)
-            echo "Unknown argument: $1"
-            shift
-            ;;
-    esac
-done
-
-if [ "${DEVELOPMENT_MODE:-0}" -eq 1 ]; then
-    echo "Running in DEVELOPMENT mode"
-else
-    echo "Running in PRODUCTION mode"
-fi
 python3 -m invoke --help 2>/dev/null >/dev/null || python3 -m pip install invoke
 python3 -m invoke virtualenv
 

--- a/settings.ini
+++ b/settings.ini
@@ -1,0 +1,2 @@
+[DEFAULT]
+development_mode = false

--- a/update.py
+++ b/update.py
@@ -13,6 +13,7 @@ import sys
 from io import StringIO
 from optparse import OptionParser
 from pathlib import Path
+from configparser import ConfigParser
 
 import requests
 from lxml import html
@@ -123,7 +124,16 @@ from regression_utils import (
     build_url,
 )
 
-development_mode = os.getenv("DEVELOPMENT_MODE") == "1"
+CONFIG_FILE = "settings.ini"
+
+config = ConfigParser()
+
+config.read(CONFIG_FILE)
+
+development_mode = config.getboolean("DEFAULT", "DEVELOPMENT_MODE", fallback=False)
+
+my_print("Development mode:", development_mode)
+
 FA_STYLE_MAP = {
     "fas": "solid",
     "far": "regular",
@@ -1524,6 +1534,8 @@ def runSphinxAutoBuild():
         "update.py",
         "--watch",
         "site",
+        "--watch",
+        "settings.ini",
         "--watch",
         "intl",
         "--watch",


### PR DESCRIPTION
## Summary by Sourcery

Switch development mode management from CLI flags to a settings.ini configuration file and integrate it into the update and Sphinx auto-build processes

New Features:
- Add settings.ini to configure development mode

Enhancements:
- Remove --development/--production flags from auto-update.sh
- Use ConfigParser in update.py to read DEVELOPMENT_MODE from settings.ini
- Print the current development mode at startup
- Watch settings.ini in the Sphinx auto-build pipeline

Chores:
- Add default settings.ini with development_mode=false