### PR TITLE
Fix invalid argument reference in callExecProcess causing the build to fail

### DIFF
--- a/update.py
+++ b/update.py
@@ -1523,7 +1523,7 @@ def runSphinxAutoBuild():
         "_static",
     ]
 
-    callExecProcess(args, uac=False)
+    callExecProcess(args, False)
 
 
 def runUpdateGolden(


### PR DESCRIPTION
This PR fixes an issue in callExecProcess where a non-existent argument was being referenced, causing the build to fail.

## Summary by Sourcery

Bug Fixes:
- Resolve a build failure by correcting the argument passed to callExecProcess in runSphinxAutoBuild.