### PR TITLE
Update range of supported python: 3.4 — 3.14

### DIFF
--- a/site/variables.inc
+++ b/site/variables.inc
@@ -25,7 +25,7 @@
 
 .. |SUPPORTED_PYTHONS| replace::
 
-   **Python 3** (3.4 — 3.13) and **Python 2** (2.6, 2.7)
+   **Python 3** (3.4 — 3.14) and **Python 2** (2.6, 2.7)
 
 .. |SHOPPING_CART_SYMBOL| raw:: html
 


### PR DESCRIPTION
Hello, @kayhayen.

Could you review and accept my change, pls?

Best Regards, Evgeny Proydakov.

## Summary by Sourcery

Documentation:
- Adjust supported Python 3 version range in site variables from 3.4–3.13 to 3.4–3.14.