### PR TITLE
Clarify CPython API/ABI compatibility for Nuitka outputs

### DIFF
--- a/site/user-documentation/user-manual.rst
+++ b/site/user-documentation/user-manual.rst
@@ -193,6 +193,41 @@ Generally, the architectures that **Debian** or **RHEL** support can be
 considered good and tested, too; for example, **RISC-V** won't pose any
 issues.
 
+CPython ABI
+===========
+
+Nuitka uses CPython's private API, `which has no stability guarantees
+<https://docs.python.org/3/c-api/stable.html>`_ and may introduce breaking
+changes even between patch releases of CPython. Extension modules produced
+by Nuitka depend on some of these changes (e.g., symbols added in newer
+patch releases) [#]_.
+
+Due to how wheels are named, this means it may not be possible to publish
+wheels compiled by Nuitka that support all patch releases for a given
+minor version of CPython.
+
+This can be mitigated by setting the ``Requires-Python`` attribute of the
+wheel to only allow CPython patch versions that are known to work. If you
+are also publishing the source distribution, then package managers can fall
+back to building from source if the wheel is incompatible [#]_.
+
+.. [#]
+
+   In *theory*, this means that using an extension module on a different
+   CPython patch release than the one used to compile it can result in
+   undefined behaviour. In practice, changes in new patch releases are
+   usually backwards compatible and typically only involve adding or
+   removing symbols (which will produce a shared library load failure
+   in the worst case, not undefined behaviour).
+
+.. [#]
+
+   If you are not publishing the source distribution, a possible solution
+   is to compile the wheel with the earliest patch release that you want
+   to support for each given minor version of CPython. This prevents Nuitka
+   from using private API features added in newer patch releases (assuming
+   that breaking changes are unlikely).
+
 **************
  Installation
 **************


### PR DESCRIPTION
Add a section to the user manual describing how binaries produced by Nuitka interact with different patch versions of CPython.

This is an important detail that affects how binaries produced by Nuitka are published and used. For example, this fact violates standard assumptions about extension module and wheel compatibility: normally you'd expect an extension module named `module.cp312-win_amd64.pyd` to support all patch versions of CPython 3.12 due to stability guarantees for the [CPython C API](https://docs.python.org/3/c-api/stable.html); however, this is not the case for Nuitka.

**Edit:** The example below appears to have been fixed in Nuitka 4.1.1, see my further comments in this thread.
> For example, CPython 3.12.6 cannot import modules produced by CPython 3.12.7, due to the use of the `_PyUnicode_InternImmortal` symbol in extension modules compiled under CPython 3.12.7. This comes from the following excerpt in the Nuitka source code:
> ```c
> #if PYTHON_VERSION >= 0x3c7
>         _PyUnicode_InternImmortal(tstate->interp, &u);
> #elif PYTHON_VERSION >= 0x300
>         PyUnicode_InternInPlace(&u);
> #else
>         insertToDictCache(unicode_cache, &u);
> #endif
> ```

In my specific use case, this causes issues since I cannot publish the source distribution, and registries cannot host multiple wheels for the same major/minor version, architecture, etc. In practice this is not as bad as it sounds since I can use the mitigations that I suggest in this new documentation section.

## Summary by Sourcery

Documentation:
- Add a user manual section explaining how Nuitka-generated binaries interact with different CPython patch versions, including limitations relative to standard extension module and wheel compatibility guarantees.