### PR TITLE
Update the docs about `data-files` - the value should be a list, not an object

### DIFF
--- a/site/user-documentation/nuitka-package-config.rst
+++ b/site/user-documentation/nuitka-package-config.rst
@@ -97,21 +97,21 @@ Data Files
 .. code:: yaml
 
    data-files:
-     dest_path: '.' # default, relative to package directory, normally not needed
-     dirs:
-       - 'dir1'
+     - dest_path: '.' # default, relative to package directory, normally not needed
+     - dirs:
+         - 'dir1'
 
-     patterns:
-       - 'file1'
-       - '*.dat'
+     - patterns:
+         - 'file1'
+         - '*.dat'
 
-     empty_dirs:
-       - 'empty_dir'
+     - empty_dirs:
+         - 'empty_dir'
 
-     empty_dir_structures:
-       - 'empty_dir_structure'
+     - empty_dir_structures:
+         - 'empty_dir_structure'
 
-     when: 'win32'
+     - when: 'win32'
 
 If a module needs data files, you can get Nuitka to copy them into the
 output with the following features.
@@ -142,8 +142,8 @@ folder and lives inside the package directory.
 
    - module-name: 'customtkinter'
      data-files:
-        dirs:
-          - 'assets'
+        - dirs:
+            - 'assets'
 
 .. note::
 
@@ -161,8 +161,8 @@ This example includes a complete folder with data files in a package.
 
    - module-name: 'tkinterweb'
      data-files:
-       dirs:
-         - 'tkhtml'
+       - dirs:
+           - 'tkhtml'
 
 .. note::
 
@@ -180,8 +180,8 @@ package.
 
    - module-name: 'Crypto.Util._raw_api'
      data-files:
-       empty_dirs:
-         - '.'
+       - empty_dirs:
+           - '.'
 
 .. note::
 


### PR DESCRIPTION
I tried to write a config file according to [the examples](https://nuitka.net/user-documentation/nuitka-package-config.html#examples) at the docs. My example file was looking similar to

```yaml
- module-name: "anyblock_exporter"
  data-files:
    patterns:
      - "config.yaml"
```

But this yields the error:

```
FATAL: Error, invalid package configuration in 'nuitka-anyblock_exporter.config.yml':
For 'anyblock_exporter' module: {'patterns': ['config.yaml']} is not of type 'array'
```

The values for `data-files` should be an array, not an object.

I updated the docs accordingly. This matches also the style at https://github.com/Nuitka/Nuitka/blob/e4d6a9686eddd0dc945385d58f71272603dd5eda/nuitka/plugins/standard/standard.nuitka-package.config.yml#L964-L967 for example.

---

Should I update the file at `bundle/user-documentation/nuitka-package-config.rst`, too or is this generated?

## Summary by Sourcery

Documentation:
- Update nuitka-package-config documentation examples so data-files is documented as an array/list rather than an object.